### PR TITLE
Remove administrator right requirments for gui

### DIFF
--- a/xrpicker-gui/assets/manifest.xml
+++ b/xrpicker-gui/assets/manifest.xml
@@ -6,9 +6,8 @@ SPDX-License-Identifier: CC0-1.0
         -->
         <security>
             <requestedPrivileges>
-                <!-- requireAdministrator for setting active runtime -->
                 <!-- uiAccess false because this is not assistive tech driving other windows -->
-                <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
             </requestedPrivileges>
         </security>
     </trustInfo>


### PR DESCRIPTION
The released xrpicker-gui.exe doesn't require administrator right, but the generated temporary xrpicker-gui-*.exe for test needs it and it breaks my local `cargo test` on Windows. This CL tries to fix this issue by using a proper settings for xrpicker-gui.exe, see https://stackoverflow.com/questions/11573444/why-is-windows-asking-for-system-administrator-privileges-for-running-executable.